### PR TITLE
Fix (gallery): Fix images overflowing grid when viewport is not a 1:1 dimension

### DIFF
--- a/webize
+++ b/webize
@@ -489,14 +489,16 @@ cat - >> "$indexHtm" <<'EOF'
                 for (var i = 0; i < images.length; i++) {
                     images[i].parentNode.style.display = "inline-block";
                     images[i].parentNode.style.verticalAlign = "top";
-                    images[i].parentNode.style.width = "calc(100% / " + tileFactor + ")";
-                    images[i].parentNode.style.height = "calc(100% / " + tileFactor + ")";
+                    images[i].parentNode.style.width = "calc(100vw / " + tileFactor + ")";
+                    images[i].parentNode.style.height = "calc(100vw / " + tileFactor + ")";
                     if (images[i].width >= images[i].height) {
-                        images[i].style.width = "100%";
+                        // Landscape
+                        images[i].style.width = "calc(100vw / " + tileFactor + ")";
                         images[i].style.height = "auto";
                     }else {
+                        // Portrait
                         images[i].style.width = "auto";
-                        images[i].style.height = "100%";
+                        images[i].style.height = "calc(100vw / " + tileFactor + ")";
                     }
                 }
                 setActiveImageIndex(activeImageIndex, true);
@@ -509,14 +511,16 @@ cat - >> "$indexHtm" <<'EOF'
                 for (var i = 0; i < images.length; i++) {
                     images[i].parentNode.style.display = "inline-block";
                     images[i].parentNode.style.verticalAlign = "top";
-                    images[i].parentNode.style.width = "calc(100% / " + tileFactor + ")";
-                    images[i].parentNode.style.height = "calc(100% / " + tileFactor + ")";
+                    images[i].parentNode.style.width = "calc(100vw / " + tileFactor + ")";
+                    images[i].parentNode.style.height = "calc(100vw / " + tileFactor + ")";
                     if (images[i].width >= images[i].height) {
-                        images[i].style.width = "100%";
+                        // Landscape
+                        images[i].style.width = "calc(100vw / " + tileFactor + ")";
                         images[i].style.height = "auto";
                     }else {
+                        // Portrait
                         images[i].style.width = "auto";
-                        images[i].style.height = "100%";
+                        images[i].style.height = "calc(100vw / " + tileFactor + ")";
                     }
                 }
                 setActiveImageIndex(activeImageIndex, true);


### PR DESCRIPTION
Fixes bug in #27