### PR TITLE
Fix (gallery): Fix arrow key navigation to scroll at most one row in tile mode

### DIFF
--- a/webize
+++ b/webize
@@ -604,7 +604,14 @@ cat - >> "$indexHtm" <<'EOF'
                     var imageholder = images[activeImageIndex].parentNode;
                     var idx = Array.from(imageholder.parentNode.children).indexOf(imageholder); // Wrapper
                     idx -= 1;
-                    setActiveImageIndex(idx, true);
+                    var scroll = (function(images, idx) {
+                        const viewportHeight = Math.max(document.documentElement.clientHeight || 0, window.innerHeight || 0);
+                        if (images[idx].parentNode.offsetTop + images[idx].parentNode.offsetHeight > window.scrollY + viewportHeight) {
+                            return true;
+                        }
+                        return false;
+                    }(images, idx));
+                    setActiveImageIndex(idx, scroll);
                 }
             };
 
@@ -616,7 +623,14 @@ cat - >> "$indexHtm" <<'EOF'
                     var imageholder = images[activeImageIndex].parentNode;
                     var idx = Array.from(imageholder.parentNode.children).indexOf(imageholder); // Wrapper
                     idx += 1;
-                    setActiveImageIndex(idx, true);
+                    var scroll = (function(images, idx) {
+                        const viewportHeight = Math.max(document.documentElement.clientHeight || 0, window.innerHeight || 0);
+                        if (images[idx].parentNode.offsetTop + images[idx].parentNode.offsetHeight > window.scrollY + viewportHeight) {
+                            return true;
+                        }
+                        return false;
+                    }(images, idx));
+                    setActiveImageIndex(idx, scroll);
                 }
             };
 
@@ -627,7 +641,14 @@ cat - >> "$indexHtm" <<'EOF'
                 if (idx <= 0) {
                     idx = 0;
                 }
-                setActiveImageIndex(idx, true);
+                var scroll = (function(images, idx) {
+                    const viewportHeight = Math.max(document.documentElement.clientHeight || 0, window.innerHeight || 0);
+                    if (images[idx].parentNode.offsetTop < window.scrollY) {
+                        return true;
+                    }
+                    return false;
+                }(images, idx));
+                setActiveImageIndex(idx, scroll);
             };
 
             var setNextRowImageAsActiveImage = function() {
@@ -637,7 +658,14 @@ cat - >> "$indexHtm" <<'EOF'
                 if (idx >= images.length - 1) {
                     idx = images.length - 1;
                 }
-                setActiveImageIndex(idx, true);
+                var scroll = (function(images, idx) {
+                    const viewportHeight = Math.max(document.documentElement.clientHeight || 0, window.innerHeight || 0);
+                    if (images[idx].parentNode.offsetTop + images[idx].parentNode.offsetHeight > window.scrollY + viewportHeight) {
+                        return true;
+                    }
+                    return false;
+                }(images, idx));
+                setActiveImageIndex(idx, scroll);
             };
 
             var setPreviousPageImageAsActiveImage = function() {


### PR DESCRIPTION
Previously, in tile mode, arrow key navigation always scroll the page such that the active image is at the top.

Now, in tile mode, arrow key navigation only scrolls the page when the active image is outside the scope of current view, and scrolls only the height of one row.